### PR TITLE
feat: Use activity name for downloaded GPX file

### DIFF
--- a/pages/api/download.js
+++ b/pages/api/download.js
@@ -1,5 +1,20 @@
 import fetch from 'node-fetch';
 
+const getActivityName = (gpxData) => {
+  const nameMatch = gpxData.match(/<name>(.*?)<\/name>/);
+  if (!nameMatch) return null;
+
+  let name = nameMatch[1];
+  if (name.startsWith('<![CDATA[') && name.endsWith(']]>')) {
+    name = name.substring(9, name.length - 3);
+  }
+  return name;
+};
+
+const sanitizeFilename = (name) => {
+  return name.replace(/[\/\\?%*:|"<>]/g, '-').trim();
+};
+
 export default async function handler(req, res) {
   const { link } = req.query;
   if (!link) {
@@ -26,8 +41,14 @@ export default async function handler(req, res) {
       return;
     }
     const gpxText = await gpxResponse.text();
+    const activityName = getActivityName(gpxText);
+    let filename = `activity_${activityId}.gpx`;
+    if (activityName) {
+      const sanitizedName = sanitizeFilename(activityName);
+      filename = `${sanitizedName}.gpx`;
+    }
     res.setHeader('Content-Type', 'application/gpx+xml');
-    res.setHeader('Content-Disposition', `attachment; filename="activity_${activityId}.gpx"`);
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.status(200).send(gpxText);
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
The downloaded GPX file is now named after the activity's name instead of its ID.

- The activity name is extracted from the GPX file data.
- The name is sanitized to remove invalid filename characters.
- If the activity name cannot be found, the filename defaults to the activity ID as a fallback.